### PR TITLE
Subdivision bugfixes

### DIFF
--- a/examples/subdiv_benchmark/main.rs
+++ b/examples/subdiv_benchmark/main.rs
@@ -1,0 +1,50 @@
+extern crate meshlite;
+
+use meshlite::mesh::Mesh;
+use meshlite::subdivide::Subdivide;
+use std::time::{Duration, Instant};
+use std::vec::Vec;
+
+fn main() {
+    let mut mesh = cube();
+    let mut all_vps = Vec::new(); // Vertices Per Second
+    for _ in 0..9 {
+        let now = Instant::now();
+        let verts_before = mesh.vertex_count;
+        mesh = mesh.subdivide();
+        let verts_after = mesh.vertex_count;
+        let added_verts = verts_after - verts_before;
+        let seconds = to_seconds_f64(&now.elapsed());
+        let verts_per_second = (added_verts as f64 / seconds).round();
+        all_vps.push(verts_per_second);
+        println!(
+            concat!(
+                "subdivided to {:#?} faces, {} vertices, ",
+                "{} vertices/second, time {:.2} ms"
+            ),
+            mesh.face_count,
+            verts_after,
+            verts_per_second,
+            seconds * 1000.0
+        );
+    }
+    println!(
+        "Vertices per second, min: {}, max: {}, avg: {}",
+        all_vps.iter().cloned().fold(0. / 0., f64::min),
+        all_vps.iter().cloned().fold(0. / 0., f64::max),
+        (all_vps.iter().sum::<f64>() / all_vps.len() as f64).round()
+    );
+}
+
+fn to_seconds_f64(d: &Duration) -> f64 {
+    d.as_secs() as f64 + d.subsec_nanos() as f64 * 1e-9
+}
+
+fn cube() -> Mesh {
+    let mut m = Mesh::new();
+    let face_id = m.add_plane(1.0, 1.0);
+    let normal = m.face_norm(face_id);
+    m.extrude_face(face_id, normal, 1.0)
+        .translate(0.0, 0.0, -0.5);
+    m
+}

--- a/src/subdivide.rs
+++ b/src/subdivide.rs
@@ -70,11 +70,11 @@ impl<'a> CatmullClarkSubdivider<'a> {
 
     fn face_data_mut(&mut self, id: Id) -> &mut FaceData {
         let center = self.mesh.face_center(id);
-        let generated_vertex_id = self.generated_mesh.add_vertex(center);
+        let internal_borrow = &mut self.generated_mesh;
         self.face_data_set.entry(id).or_insert_with(|| {
             let mut data = FaceData::new();
             data.average_of_points = center;
-            data.generated_vertex_id = generated_vertex_id;
+            data.generated_vertex_id = internal_borrow.add_vertex(center);
             Box::new(data)
         })
     }
@@ -97,11 +97,12 @@ impl<'a> CatmullClarkSubdivider<'a> {
            start_vertex_position,
            stop_vertex_position,
         ];
-        let generated_vertex_id = self.generated_mesh.add_vertex(Point3::centroid(&array));
+        let internal_borrow = &mut self.generated_mesh;
         self.edge_data_set.entry(id).or_insert_with(|| {
             let mut data = EdgeData::new();
             data.mid_point = mid_point;
-            data.generated_vertex_id = generated_vertex_id;
+            let center = Point3::centroid(&array);
+            data.generated_vertex_id = internal_borrow.add_vertex(center);
             Box::new(data)
         })
     }
@@ -132,10 +133,10 @@ impl<'a> CatmullClarkSubdivider<'a> {
         let position = (((average_of_edge * 2.0) + bury_center.to_vec()) + 
                         (vertex_position.to_vec() * ((average_of_faces.len() as i32 - 3).abs() as f32))) / 
             (average_of_faces.len() as f32);
-        let generated_vertex_id = self.generated_mesh.add_vertex(position);
+        let internal_borrow = &mut self.generated_mesh;
         self.vertex_data_set.entry(id).or_insert_with(|| {
             let mut data = VertexData::new();
-            data.generated_vertex_id = generated_vertex_id;
+            data.generated_vertex_id = internal_borrow.add_vertex(position);
             Box::new(data)
         })
     }


### PR DESCRIPTION
This PR fixes a huge number of extra vertices (by roughly a factor of 20) that were generated during subdivision. I added a new example that can be used to show the difference in the output data from the subdivision. This is the output from the new example:

Original                                                                                                                                                                                                             
----------
                                                                                                                                                                                                                     
subdivided to 24 faces, **462** vertices, ~3435854~ vertices/second, time 0.13 ms                                                                                                                                          
subdivided to 96 faces, **2136** vertices, ~2671335~ vertices/second, time 0.63 ms                                                                                                                                         
subdivided to 384 faces, **8832** vertices, ~2761288~ vertices/second, time 2.42 ms                                                                                                                                        
subdivided to 1536 faces, **35616** vertices, ~2701504~ vertices/second, time 9.91 ms                                                                                                                                      
subdivided to 6144 faces, **142752** vertices, ~2511635~ vertices/second, time 42.66 ms                                                                                                                                    
subdivided to 24576 faces, **571296** vertices, ~2494327~ vertices/second, time 171.81 ms                                                                                                                                  
subdivided to 98304 faces, **2285472** vertices, ~2460938~ vertices/second, time 696.55 ms                                                                                                                                 
subdivided to 393216 faces, **9142176** vertices, ~2458577~ vertices/second, time 2788.89 ms                                                                                                                               
subdivided to 1572864 faces, **36568992** vertices, ~2429601~ vertices/second, ___time 11288.61 ms___
Vertices per second, min: ~2429601~, max: ~3435854~, avg: ~2658340~
                                                                                                                                                                                                                     
With bugfixes                                                                                                                                                                                                          
-----------------
                                                                                                                                                                                                                     
subdivided to 24 faces, **26** vertices, 187803 vertices/second, time 0.10 ms                                                                                                                                            
subdivided to 96 faces, **98** vertices, 158059 vertices/second, time 0.46 ms                                                                                                                                            
subdivided to 384 faces, **386** vertices, 168812 vertices/second, time 1.71 ms                                                                                                                                          
subdivided to 1536 faces, **1538** vertices, 173485 vertices/second, time 6.64 ms                                                                                                                                        
subdivided to 6144 faces, **6146** vertices, 165626 vertices/second, time 27.82 ms                                                                                                                                       
subdivided to 24576 faces, **24578** vertices, 161707 vertices/second, time 113.98 ms                                                                                                                                    
subdivided to 98304 faces, **98306** vertices, 161655 vertices/second, time 456.08 ms                                                                                                                                    
subdivided to 393216 faces, **393218** vertices, 157197 vertices/second, time 1876.07 ms                                                                                                                                 
subdivided to 1572864 faces, **1572866** vertices, 154033 vertices/second, ___time 7658.43 ms___
Vertices per second, min: 154033, max: 187803, avg: 165375                                                                                                                                                           
                                                                                                                                                                                                                     
**11288 / 7658 = 1.474**   

In addition to avoiding the extra vertices, the subdivision is almost 50% faster :smiley: 
