### PR TITLE
More optimizations for `subdivide()`

### DIFF
--- a/profile_dtrace.sh
+++ b/profile_dtrace.sh
@@ -3,6 +3,7 @@
 # Based on http://carol-nichols.com/2017/04/20/rust-profiling-with-dtrace-on-osx/
 # Make sure to uncomment the debug flag under [profile.release] in Cargo.toml.
 # Needs https://github.com/brendangregg/FlameGraph at ../FlameGraph/
+cargo build --release --example subdiv_benchmark
 sudo dtrace -c './target/release/examples/subdiv_benchmark' -o out.stacks -n 'profile-997 /execname == "subdiv_benchmark"/ { @[ustack(100)] = count(); }'
 ../FlameGraph/stackcollapse.pl out.stacks | ../FlameGraph/flamegraph.pl > flame.svg
 

--- a/profile_perf.sh
+++ b/profile_perf.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 # Based on https://gist.github.com/KodrAus/97c92c07a90b1fdd6853654357fd557a
-sudo perf record --call-graph dwarf target/release/examples/subdiv_benchmark
+# Make sure to uncomment the debug flag under [profile.release] in Cargo.toml.
+# Needs https://github.com/brendangregg/FlameGraph at ../FlameGraph/
+cargo build --release --example subdiv_benchmark
+sudo perf record --call-graph dwarf -F 10000 target/release/examples/subdiv_benchmark
 sudo chown $USER perf.data
 perf script | ../FlameGraph/stackcollapse-perf.pl | ../FlameGraph/flamegraph.pl > flame.svg
 

--- a/src/iterator.rs
+++ b/src/iterator.rs
@@ -11,11 +11,11 @@ impl<'a> Iterator for FaceIterator<'a> {
 
     fn next(&mut self) -> Option<Id> {
         while self.index < self.mesh.faces.len() {
-            if self.mesh.faces[self.index].alive {
-                self.index += 1;
-                return Some(self.mesh.faces[self.index - 1].id);
-            }
+            let face = &self.mesh.faces[self.index];
             self.index += 1;
+            if face.alive {
+                return Some(face.id)
+            }
         }
         None
     }

--- a/src/subdivide.rs
+++ b/src/subdivide.rs
@@ -166,8 +166,7 @@ impl<'a> CatmullClarkSubdivider<'a> {
             // overallocation.
             self.generated_mesh.edges.reserve(halfedge_prediction / 2);
         }
-        let face_id_vec = FaceIterator::new(self.mesh).into_vec();
-        for face_id in face_id_vec {
+        for face_id in FaceIterator::new(self.mesh) {
             let face_vertex_id = self.face_data_mut(face_id).generated_vertex_id;
             let face_halfedge = self.mesh.face(face_id).unwrap().halfedge;
             let face_halfedge_id_vec = FaceHalfedgeIterator::new(self.mesh, face_halfedge).into_vec();
@@ -182,11 +181,12 @@ impl<'a> CatmullClarkSubdivider<'a> {
                 let e2_vertex_id = self.edge_data_mut(next_halfedge_id).generated_vertex_id;
                 let vertex_generated_id = self.vertex_data_mut(vertex_id).generated_vertex_id;
                 let added_face_id = self.generated_mesh.add_face();
-                let mut added_halfedges : Vec<(Id, Id)> = Vec::new();
-                added_halfedges.push((self.generated_mesh.add_halfedge(), face_vertex_id));
-                added_halfedges.push((self.generated_mesh.add_halfedge(), e1_vertex_id));
-                added_halfedges.push((self.generated_mesh.add_halfedge(), vertex_generated_id));
-                added_halfedges.push((self.generated_mesh.add_halfedge(), e2_vertex_id));
+                let mut added_halfedges = [
+                    (self.generated_mesh.add_halfedge(), face_vertex_id),
+                    (self.generated_mesh.add_halfedge(), e1_vertex_id),
+                    (self.generated_mesh.add_halfedge(), vertex_generated_id),
+                    (self.generated_mesh.add_halfedge(), e2_vertex_id)
+                ];
                 for &(added_halfedge_id, added_vertex_id) in added_halfedges.iter() {
                     self.generated_mesh.vertex_mut(added_vertex_id).unwrap().halfedges.insert(added_halfedge_id);
                     self.generated_mesh.halfedge_mut(added_halfedge_id).unwrap().face = added_face_id;

--- a/src/subdivide.rs
+++ b/src/subdivide.rs
@@ -1,10 +1,10 @@
-use cgmath::Point3;
 use cgmath::EuclideanSpace;
+use cgmath::Point3;
 use fnv::FnvHashMap;
-use mesh::Mesh;
-use mesh::Id;
-use iterator::FaceIterator;
 use iterator::FaceHalfedgeIterator;
+use iterator::FaceIterator;
+use mesh::Id;
+use mesh::Mesh;
 use std::mem;
 
 struct FaceData {
@@ -47,13 +47,13 @@ fn face_data_mut<'a>(
     input: &Mesh,
     id: Id,
     face_data_set: &'a mut FnvHashMap<Id, FaceData>,
-    output: &mut Mesh)
--> &'a mut FaceData {
+    output: &mut Mesh,
+) -> &'a mut FaceData {
     face_data_set.entry(id).or_insert_with(|| {
         let average_of_points = input.face_center(id);
         FaceData {
             average_of_points,
-            generated_vertex_id: output.add_vertex(average_of_points)
+            generated_vertex_id: output.add_vertex(average_of_points),
         }
     })
 }
@@ -100,31 +100,34 @@ impl<'a> CatmullClarkSubdivider<'a> {
         let edge_data_set = &mut self.edge_data_set;
         edge_data_set.entry(id).or_insert_with(|| {
             let mid_point = mesh.edge_center(id);
-            let (halfedge_face_id, opposite_face_id, next_halfedge_vertex_id, start_vertex_position) = {
+            let (
+                halfedge_face_id,
+                opposite_face_id,
+                next_halfedge_vertex_id,
+                start_vertex_position,
+            ) = {
                 let halfedge = mesh.halfedge(id).unwrap();
-                (halfedge.face, 
-                    mesh.halfedge(halfedge.opposite).unwrap().face, 
+                (
+                    halfedge.face,
+                    mesh.halfedge(halfedge.opposite).unwrap().face,
                     mesh.halfedge(halfedge.next).unwrap().vertex,
-                    mesh.vertex(halfedge.vertex).unwrap().position)
+                    mesh.vertex(halfedge.vertex).unwrap().position,
+                )
             };
             let stop_vertex_position = mesh.vertex(next_halfedge_vertex_id).unwrap().position;
-            let f1_data_average = face_data_mut(
-                mesh,
-                halfedge_face_id,
-                face_data_set,
-                generated_mesh).average_of_points;
-            let f2_data_average = face_data_mut(
-                mesh,
-                opposite_face_id,
-                face_data_set,
-                generated_mesh).average_of_points;
+            let f1_data_average =
+                face_data_mut(mesh, halfedge_face_id, face_data_set, generated_mesh)
+                    .average_of_points;
+            let f2_data_average =
+                face_data_mut(mesh, opposite_face_id, face_data_set, generated_mesh)
+                    .average_of_points;
             let mut data = EdgeData::new();
             data.mid_point = mid_point;
             let center = Point3::centroid(&[
-               f1_data_average,
-               f2_data_average,
-               start_vertex_position,
-               stop_vertex_position,
+                f1_data_average,
+                f2_data_average,
+                start_vertex_position,
+                stop_vertex_position,
             ]);
             data.generated_vertex_id = generated_mesh.add_vertex(center);
             data
@@ -140,25 +143,28 @@ impl<'a> CatmullClarkSubdivider<'a> {
         &mut self,
         id: Id,
         tmp_avg_of_faces: &mut Vec<Point3<f32>>,
-        tmp_avg_of_edge_mids: &mut Vec<Point3<f32>>)
-    -> &mut VertexData {
+        tmp_avg_of_edge_mids: &mut Vec<Point3<f32>>,
+    ) -> &mut VertexData {
         tmp_avg_of_faces.clear();
         tmp_avg_of_edge_mids.clear();
         let vertex = self.mesh.vertex(id).unwrap();
         for halfedge_id in vertex.halfedges.iter() {
             let halfedge_face_id = self.mesh.halfedge(*halfedge_id).unwrap().face;
-            tmp_avg_of_faces.push(face_data_mut(
-                &self.mesh,
-                halfedge_face_id,
-                &mut self.face_data_set,
-                &mut self.generated_mesh).average_of_points);
+            tmp_avg_of_faces.push(
+                face_data_mut(
+                    &self.mesh,
+                    halfedge_face_id,
+                    &mut self.face_data_set,
+                    &mut self.generated_mesh,
+                ).average_of_points,
+            );
             tmp_avg_of_edge_mids.push(self.edge_data_mut(*halfedge_id).mid_point);
         }
         let bury_center = Point3::centroid(tmp_avg_of_faces);
         let average_of_edge = Point3::centroid(tmp_avg_of_edge_mids);
-        let position = (((average_of_edge * 2.0) + bury_center.to_vec()) + 
-                        (vertex.position.to_vec() * ((tmp_avg_of_faces.len() as i32 - 3).abs() as f32))) /
-            (tmp_avg_of_faces.len() as f32);
+        let position = (((average_of_edge * 2.0) + bury_center.to_vec())
+            + (vertex.position.to_vec() * ((tmp_avg_of_faces.len() as i32 - 3).abs() as f32)))
+            / (tmp_avg_of_faces.len() as f32);
         let internal_borrow = &mut self.generated_mesh;
         self.vertex_data_set.entry(id).or_insert_with(|| {
             let mut data = VertexData::new();
@@ -179,21 +185,21 @@ impl<'a> CatmullClarkSubdivider<'a> {
         self.generated_mesh.vertices.reserve(
             self.mesh.vertex_count         // No vertices are removed
             + self.mesh.halfedge_count / 2 // Each edge produce a new point
-            + self.mesh.face_count         // Each face produce a new point
+            + self.mesh.face_count, // Each face produce a new point
         );
         self.generated_mesh.faces.reserve(
-            self.mesh.face_count * 4       // Optimized for quad meshes
+            self.mesh.face_count * 4, // Optimized for quad meshes
         );
         // Is this true for all meshes? If false, this is probably still ok
-        // since the worst-case here is degraded performance or 
+        // since the worst-case here is degraded performance or
         // overallocation.
         self.generated_mesh.edges.reserve(halfedge_prediction / 2);
         self.face_data_set.reserve(self.mesh.face_count);
         self.edge_data_set.reserve(self.mesh.edges.len());
         self.vertex_data_set.reserve(self.mesh.vertex_count);
     }
-    
-    fn generated_mesh_mut(&mut self) ->&mut Mesh {
+
+    fn generated_mesh_mut(&mut self) -> &mut Mesh {
         if self.finished {
             return &mut self.generated_mesh;
         }
@@ -206,9 +212,11 @@ impl<'a> CatmullClarkSubdivider<'a> {
                 &self.mesh,
                 face_id,
                 &mut self.face_data_set,
-                &mut self.generated_mesh).generated_vertex_id;
+                &mut self.generated_mesh,
+            ).generated_vertex_id;
             let face_halfedge = self.mesh.face(face_id).unwrap().halfedge;
-            let face_halfedge_id_vec = FaceHalfedgeIterator::new(self.mesh, face_halfedge).into_vec();
+            let face_halfedge_id_vec =
+                FaceHalfedgeIterator::new(self.mesh, face_halfedge).into_vec();
             for halfedge_id in face_halfedge_id_vec {
                 let (next_halfedge_id, vertex_id) = {
                     let halfedge = self.mesh.halfedge(halfedge_id).unwrap();
@@ -218,23 +226,35 @@ impl<'a> CatmullClarkSubdivider<'a> {
                 };
                 let e1_vertex_id = self.edge_data_mut(halfedge_id).generated_vertex_id;
                 let e2_vertex_id = self.edge_data_mut(next_halfedge_id).generated_vertex_id;
-                let vertex_generated_id = self.vertex_data_mut(
-                    vertex_id,
-                    &mut tmp_avg_of_faces,
-                    &mut tmp_avg_of_edge_mids).generated_vertex_id;
+                let vertex_generated_id = self
+                    .vertex_data_mut(vertex_id, &mut tmp_avg_of_faces, &mut tmp_avg_of_edge_mids)
+                    .generated_vertex_id;
                 let added_face_id = self.generated_mesh.add_face();
                 let mut added_halfedges = [
                     (self.generated_mesh.add_halfedge(), face_vertex_id),
                     (self.generated_mesh.add_halfedge(), e1_vertex_id),
                     (self.generated_mesh.add_halfedge(), vertex_generated_id),
-                    (self.generated_mesh.add_halfedge(), e2_vertex_id)
+                    (self.generated_mesh.add_halfedge(), e2_vertex_id),
                 ];
                 for &(added_halfedge_id, added_vertex_id) in added_halfedges.iter() {
-                    self.generated_mesh.vertex_mut(added_vertex_id).unwrap().halfedges.insert(added_halfedge_id);
-                    self.generated_mesh.halfedge_mut(added_halfedge_id).unwrap().face = added_face_id;
-                    self.generated_mesh.halfedge_mut(added_halfedge_id).unwrap().vertex = added_vertex_id;
+                    self.generated_mesh
+                        .vertex_mut(added_vertex_id)
+                        .unwrap()
+                        .halfedges
+                        .insert(added_halfedge_id);
+                    self.generated_mesh
+                        .halfedge_mut(added_halfedge_id)
+                        .unwrap()
+                        .face = added_face_id;
+                    self.generated_mesh
+                        .halfedge_mut(added_halfedge_id)
+                        .unwrap()
+                        .vertex = added_vertex_id;
                 }
-                self.generated_mesh.face_mut(added_face_id).unwrap().halfedge = added_halfedges[0].0;
+                self.generated_mesh
+                    .face_mut(added_face_id)
+                    .unwrap()
+                    .halfedge = added_halfedges[0].0;
                 for i in 0..added_halfedges.len() {
                     let first = added_halfedges[i].0;
                     let second = added_halfedges[(i + 1) % added_halfedges.len()].0;


### PR DESCRIPTION
Before
-----
```
faces     | vertices  | halfedges | edges     | verts/s   | time (ms)
----------+-----------+-----------+-----------+-----------+-----------
24        | 26        | 96        | 48        | 172082    | 0.10     
96        | 98        | 384       | 192       | 275558    | 0.26     
384       | 386       | 1536      | 768       | 290359    | 0.99     
1536      | 1538      | 6144      | 3072      | 319219    | 3.61     
6144      | 6146      | 24576     | 12288     | 297132    | 15.51    
24576     | 24578     | 98304     | 49152     | 293099    | 62.89    
98304     | 98306     | 393216    | 196608    | 285825    | 257.95   
393216    | 393218    | 1572864   | 786432    | 279832    | 1053.89  
1572864   | 1572866   | 6291456   | 3145728   | 274094    | 4303.81  
Vertices per second, min: 172082, max: 319219, avg: 276356
```

After
-----
```
faces     | vertices  | halfedges | edges     | verts/s   | time (ms)
----------+-----------+-----------+-----------+-----------+-----------
24        | 26        | 96        | 48        | 389678    | 0.05     
96        | 98        | 384       | 192       | 474868    | 0.15     
384       | 386       | 1536      | 768       | 670404    | 0.43     
1536      | 1538      | 6144      | 3072      | 647458    | 1.78     
6144      | 6146      | 24576     | 12288     | 671209    | 6.87     
24576     | 24578     | 98304     | 49152     | 561476    | 32.83    
98304     | 98306     | 393216    | 196608    | 535278    | 137.74   
393216    | 393218    | 1572864   | 786432    | 507164    | 581.49   
1572864   | 1572866   | 6291456   | 3145728   | 485607    | 2429.22  
Vertices per second, min: 389678, max: 671209, avg: 549238
```

Roughly twice as fast as the master branch :)

I did also run rustfmt on the `src/subdivide.rs` as the last commit so it can
easily be reverted if you don't like it.
