### PR TITLE
Optimize subdivide 3

### DIFF
--- a/src/mesh.rs
+++ b/src/mesh.rs
@@ -7,6 +7,7 @@ use std::io;
 use std::vec::Vec;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use fnv::FnvHashSet;
 use fnv::FnvHashMap;
 use iterator::FaceHalfedgeIterator;
 use iterator::FaceIterator;
@@ -22,7 +23,7 @@ pub type Id = usize;
 pub struct Vertex {
     pub id: Id,
     pub position: Point3<f32>,
-    pub halfedges: HashSet<Id>,
+    pub halfedges: FnvHashSet<Id>,
     pub prev: Id,
     pub next: Id,
     pub alive: bool,
@@ -383,7 +384,7 @@ impl Mesh {
         let new_id = self.vertices.len() + 1;
         self.vertices.push(Vertex {
             id: new_id,
-            halfedges: HashSet::new(),
+            halfedges: FnvHashSet::default(),
             prev: 0,
             next: 0,
             position : position,
@@ -451,7 +452,7 @@ impl Mesh {
         }
         let (&first_id, _) = linked_vertices.iter().next().unwrap();
         let mut vert = first_id;
-        let mut visited_sets = HashSet::new();
+        let mut visited_sets = FnvHashSet::default();
         let mut added_vertices = Vec::new();
         added_vertices.push(first_id);
         visited_sets.insert(first_id);

--- a/src/subdivide.rs
+++ b/src/subdivide.rs
@@ -158,7 +158,7 @@ impl<'a> CatmullClarkSubdivider<'a> {
         // TODO: Try to replace this with Vec or some other efficient lookup.
         output.edges.reserve(halfedge_prediction / 2);
 
-        // input.rs is using 1-based indexing so we need + 1 for the length of
+        // mesh.rs is using 1-based indexing so we need + 1 for the length of
         // each Vec below. It is also not enough to use input.halfedge_count,
         // the count represents "living" elements and may be less than the
         // largest id (index).

--- a/src/subdivide.rs
+++ b/src/subdivide.rs
@@ -19,6 +19,9 @@ struct EdgeData {
     generated_vertex_id: Id,
 }
 
+// A vertex Id in the output mesh.
+// This is a simple id wrapper so we derive value semantics.
+#[derive(Copy, Clone)]
 struct VertexData {
     generated_vertex_id: Id,
 }
@@ -48,42 +51,6 @@ fn face_data_mut<'a>(
     })
 }
 
-/// Allows efficient usage of the hash map entry API by splitting
-/// CatmullClarkSubdivider::Self into multiple borrows.
-fn vertex_data_mut<'a>(
-    input: &Mesh,
-    id: Id,
-    tmp_avg_of_faces: &mut Vec<Point3<f32>>,
-    tmp_avg_of_edge_mids: &mut Vec<Point3<f32>>,
-    face_data_set: &mut FnvHashMap<Id, FaceData>,
-    vertex_data_set: &'a mut FnvHashMap<Id, VertexData>,
-    edge_data_set: &mut FnvHashMap<Id, EdgeData>,
-    output: &mut Mesh,
-) -> &'a mut VertexData {
-    vertex_data_set.entry(id).or_insert_with(|| {
-        tmp_avg_of_faces.clear();
-        tmp_avg_of_edge_mids.clear();
-        let vertex = input.vertex(id).unwrap();
-        for halfedge_id in vertex.halfedges.iter() {
-            let halfedge_face_id = input.halfedge(*halfedge_id).unwrap().face;
-            tmp_avg_of_faces.push(
-                face_data_mut(input, halfedge_face_id, face_data_set, output).average_of_points,
-            );
-            tmp_avg_of_edge_mids.push(
-                edge_data_mut(input, *halfedge_id, face_data_set, edge_data_set, output).mid_point,
-            );
-        }
-        let bury_center = Point3::centroid(tmp_avg_of_faces);
-        let average_of_edge = Point3::centroid(tmp_avg_of_edge_mids);
-        let position = (((average_of_edge * 2.0) + bury_center.to_vec())
-            + (vertex.position.to_vec() * ((tmp_avg_of_faces.len() as i32 - 3).abs() as f32)))
-            / (tmp_avg_of_faces.len() as f32);
-        let mut data = VertexData::new();
-        data.generated_vertex_id = output.add_vertex(position);
-        data
-    })
-}
-
 fn edge_data_mut<'a>(
     input: &Mesh,
     id: Id,
@@ -94,7 +61,12 @@ fn edge_data_mut<'a>(
     let id = input.peek_same_halfedge(id);
     edge_data_set.entry(id).or_insert_with(|| {
         let mid_point = input.edge_center(id);
-        let (halfedge_face_id, opposite_face_id, next_halfedge_vertex_id, start_vertex_position) = {
+        let (
+            halfedge_face_id,
+            opposite_face_id,
+            next_halfedge_vertex_id,
+            start_vertex_position,
+        ) = {
             let halfedge = input.halfedge(id).unwrap();
             (
                 halfedge.face,
@@ -103,11 +75,14 @@ fn edge_data_mut<'a>(
                 input.vertex(halfedge.vertex).unwrap().position,
             )
         };
-        let stop_vertex_position = input.vertex(next_halfedge_vertex_id).unwrap().position;
+        let stop_vertex_position =
+            input.vertex(next_halfedge_vertex_id).unwrap().position;
         let f1_data_average =
-            face_data_mut(input, halfedge_face_id, face_data_set, output).average_of_points;
+            face_data_mut(input, halfedge_face_id, face_data_set, output)
+                .average_of_points;
         let f2_data_average =
-            face_data_mut(input, opposite_face_id, face_data_set, output).average_of_points;
+            face_data_mut(input, opposite_face_id, face_data_set, output)
+                .average_of_points;
         let center = Point3::centroid(&[
             f1_data_average,
             f2_data_average,
@@ -131,10 +106,10 @@ pub struct CatmullClarkSubdivider<'a> {
     face_data_set: FnvHashMap<Id, FaceData>,
 
     /// Destination mesh
-    generated_mesh: Mesh,
+    output: Mesh,
 
     /// Source mesh
-    mesh: &'a Mesh,
+    input: &'a Mesh,
 
     // Temporary and reusable memory buffer for vertex_data_mut().
     tmp_avg_of_faces: Vec<Point3<f32>>,
@@ -142,128 +117,164 @@ pub struct CatmullClarkSubdivider<'a> {
     // Temporary and reusable memory buffer for vertex_data_mut().
     tmp_avg_of_edge_mids: Vec<Point3<f32>>,
 
-    /// Temporary buffer, TODO: Describe purpose.
-    vertex_data_set: FnvHashMap<Id, VertexData>,
+    /// Maps VERTEX ID in the INPUT mesh to VertexData.
+    vertex_data_set: Vec<Option<VertexData>>,
 }
 
 impl<'a> CatmullClarkSubdivider<'a> {
-    pub fn new(mesh: &'a Mesh) -> Self {
+    pub fn new(input: &'a Mesh) -> Self {
         CatmullClarkSubdivider {
             edge_data_set: FnvHashMap::default(),
             face_data_set: FnvHashMap::default(),
-            generated_mesh: Mesh::new(),
-            mesh: mesh,
+            output: Mesh::new(),
+            input,
             tmp_avg_of_edge_mids: Vec::new(),
             tmp_avg_of_faces: Vec::new(),
-            vertex_data_set: FnvHashMap::default(),
+            vertex_data_set: Vec::new(),
         }
     }
 
     pub fn generate(mut self) -> Mesh {
         self.reserve_internal_memory();
-        for face_id in FaceIterator::new(self.mesh) {
+        for face_id in FaceIterator::new(self.input) {
             let face_vertex_id = face_data_mut(
-                &self.mesh,
+                &self.input,
                 face_id,
                 &mut self.face_data_set,
-                &mut self.generated_mesh,
+                &mut self.output,
             ).generated_vertex_id;
-            let face_halfedge = self.mesh.face(face_id).unwrap().halfedge;
+            let face_halfedge = self.input.face(face_id).unwrap().halfedge;
             let face_halfedge_id_vec =
-                FaceHalfedgeIterator::new(self.mesh, face_halfedge).into_vec();
+                FaceHalfedgeIterator::new(self.input, face_halfedge).into_vec();
             for halfedge_id in face_halfedge_id_vec {
                 let (next_halfedge_id, vertex_id) = {
-                    let halfedge = self.mesh.halfedge(halfedge_id).unwrap();
+                    let halfedge = self.input.halfedge(halfedge_id).unwrap();
                     let next_halfedge_id = halfedge.next;
-                    let next_halfedge_start = self.mesh.halfedge(next_halfedge_id).unwrap().vertex;
+                    let next_halfedge_start =
+                        self.input.halfedge(next_halfedge_id).unwrap().vertex;
                     (next_halfedge_id, next_halfedge_start)
                 };
-                let e1_vertex_id = self.edge_data_mut(halfedge_id).generated_vertex_id;
-                let e2_vertex_id = self.edge_data_mut(next_halfedge_id).generated_vertex_id;
-                let vertex_generated_id = self.vertex_data_mut(vertex_id).generated_vertex_id;
-                let added_face_id = self.generated_mesh.add_face();
+                let e1_vertex_id =
+                    self.edge_data_mut(halfedge_id).generated_vertex_id;
+                let e2_vertex_id =
+                    self.edge_data_mut(next_halfedge_id).generated_vertex_id;
+                let vertex_generated_id =
+                    self.vertex_data_mut(vertex_id).generated_vertex_id;
+                let added_face_id = self.output.add_face();
                 let mut added_halfedges = [
-                    (self.generated_mesh.add_halfedge(), face_vertex_id),
-                    (self.generated_mesh.add_halfedge(), e1_vertex_id),
-                    (self.generated_mesh.add_halfedge(), vertex_generated_id),
-                    (self.generated_mesh.add_halfedge(), e2_vertex_id),
+                    (self.output.add_halfedge(), face_vertex_id),
+                    (self.output.add_halfedge(), e1_vertex_id),
+                    (self.output.add_halfedge(), vertex_generated_id),
+                    (self.output.add_halfedge(), e2_vertex_id),
                 ];
-                for &(added_halfedge_id, added_vertex_id) in added_halfedges.iter() {
-                    self.generated_mesh
+                for &(added_halfedge_id, added_vertex_id) in
+                    added_halfedges.iter()
+                {
+                    self.output
                         .vertex_mut(added_vertex_id)
                         .unwrap()
                         .halfedges
                         .insert(added_halfedge_id);
-                    self.generated_mesh
-                        .halfedge_mut(added_halfedge_id)
-                        .unwrap()
-                        .face = added_face_id;
-                    self.generated_mesh
+                    self.output.halfedge_mut(added_halfedge_id).unwrap().face =
+                        added_face_id;
+                    self.output
                         .halfedge_mut(added_halfedge_id)
                         .unwrap()
                         .vertex = added_vertex_id;
                 }
-                self.generated_mesh
-                    .face_mut(added_face_id)
-                    .unwrap()
-                    .halfedge = added_halfedges[0].0;
+                self.output.face_mut(added_face_id).unwrap().halfedge =
+                    added_halfedges[0].0;
                 for i in 0..added_halfedges.len() {
                     let first = added_halfedges[i].0;
-                    let second = added_halfedges[(i + 1) % added_halfedges.len()].0;
-                    self.generated_mesh.link_halfedges(first, second);
+                    let second =
+                        added_halfedges[(i + 1) % added_halfedges.len()].0;
+                    self.output.link_halfedges(first, second);
                 }
             }
         }
-        self.generated_mesh
+        self.output
     }
 
     /// Should be called once, internally, at subdivision start.
     fn reserve_internal_memory(&mut self) {
         // Each halfedge produce 3 new
-        let halfedge_prediction = self.mesh.halfedge_count * 4;
-        self.generated_mesh.halfedges.reserve(halfedge_prediction);
-        self.generated_mesh.vertices.reserve(
-            self.mesh.vertex_count         // No vertices are removed
-            + self.mesh.halfedge_count / 2 // Each edge produce a new point
-            + self.mesh.face_count,        // Each face produce a new point
+        let halfedge_prediction = self.input.halfedge_count * 4;
+        self.output.halfedges.reserve(halfedge_prediction);
+
+        self.output.vertices.reserve(
+            self.input.vertex_count         // No vertices are removed
+            + self.input.halfedge_count / 2 // Each edge produce a new point
+            + self.input.face_count, // Each face produce a new point
         );
-        self.generated_mesh.faces.reserve(
-            self.mesh.face_count * 4,      // Optimize for quads
+        self.output.faces.reserve(
+            self.input.face_count * 4, // Optimize for quads
         );
+
         // Is this true for all meshes? If false, this is probably still ok
         // since the worst-case here is degraded performance or
         // overallocation.
-        self.generated_mesh.edges.reserve(halfedge_prediction / 2);
-        self.face_data_set.reserve(self.mesh.face_count);
-        self.edge_data_set.reserve(self.mesh.edges.len());
-        self.vertex_data_set.reserve(self.mesh.vertex_count);
+        self.output.edges.reserve(halfedge_prediction / 2);
+
+        self.face_data_set.reserve(self.input.face_count);
+        self.edge_data_set.reserve(self.input.edges.len());
+
+        // input.rs is using 1-based indexing so we need + 1 here.
+        self.vertex_data_set = vec![None; self.input.vertex_count + 1];
     }
 
     /// Helps to reduce the syntax noise when a Self is available. Splits Self
     /// into multiple mutable borrows.
     fn edge_data_mut(&mut self, halfedge_id: Id) -> &EdgeData {
         edge_data_mut(
-            &self.mesh,
+            &self.input,
             halfedge_id,
             &mut self.face_data_set,
             &mut self.edge_data_set,
-            &mut self.generated_mesh,
+            &mut self.output,
         )
     }
 
-    /// Helps to reduce the syntax noise when a Self is available. Splits Self
-    /// into multiple mutable borrows.
-    fn vertex_data_mut(&mut self, vertex_id: Id) -> &VertexData {
-        vertex_data_mut(
-            &self.mesh,
-            vertex_id,
-            &mut self.tmp_avg_of_faces,
-            &mut self.tmp_avg_of_edge_mids,
-            &mut self.face_data_set,
-            &mut self.vertex_data_set,
-            &mut self.edge_data_set,
-            &mut self.generated_mesh,
-        )
+    /// Get or create a vertex in the new mesh.
+    /// The vertex_id paremeter refers to a vertex in the input mesh.
+    /// The returned VertexData (vertex id) refers to the output mesh.
+    fn vertex_data_mut(&mut self, vertex_id: Id) -> VertexData {
+        if let Some(data) = self.vertex_data_set[vertex_id] {
+            return data;
+        }
+        self.tmp_avg_of_faces.clear();
+        self.tmp_avg_of_edge_mids.clear();
+        let vertex = self.input.vertex(vertex_id).unwrap();
+        for halfedge_id in vertex.halfedges.iter() {
+            let halfedge_face_id =
+                self.input.halfedge(*halfedge_id).unwrap().face;
+            self.tmp_avg_of_faces.push(
+                face_data_mut(
+                    &self.input,
+                    halfedge_face_id,
+                    &mut self.face_data_set,
+                    &mut self.output,
+                ).average_of_points,
+            );
+            self.tmp_avg_of_edge_mids.push(
+                edge_data_mut(
+                    &self.input,
+                    *halfedge_id,
+                    &mut self.face_data_set,
+                    &mut self.edge_data_set,
+                    &mut self.output,
+                ).mid_point,
+            );
+        }
+        let barycenter = Point3::centroid(&self.tmp_avg_of_faces);
+        let average_of_edge = Point3::centroid(&self.tmp_avg_of_edge_mids);
+        let position = (((average_of_edge * 2.0) + barycenter.to_vec())
+            + (vertex.position.to_vec()
+                * ((self.tmp_avg_of_faces.len() as i32 - 3).abs() as f32)))
+            / (self.tmp_avg_of_faces.len() as f32);
+        let mut data = VertexData::new();
+        data.generated_vertex_id = self.output.add_vertex(position);
+        self.vertex_data_set[vertex_id] = Some(data);
+        data
     }
 }
 

--- a/src/subdivide.rs
+++ b/src/subdivide.rs
@@ -149,11 +149,11 @@ impl<'a> CatmullClarkSubdivider<'a> {
         );
 
         // Is this prediction true for all meshes? If false, this is probably
-        // still ok since the worst-case here is degraded performance or
+        // still ok since the worst-case here is degraded performance and
         // overallocation.
         //
         // Insertion in this collection is at the time of writing the single
-        // largest time consumer that sticks out when profiling subdivision.
+        // largest time sink that sticks out when profiling subdivision.
         //
         // TODO: Try to replace this with Vec or some other efficient lookup.
         output.edges.reserve(halfedge_prediction / 2);


### PR DESCRIPTION
Before
--------
```
faces     | vertices  | halfedges | edges     | verts/s   | time (ms)
----------+-----------+-----------+-----------+-----------+-----------
24        | 26        | 96        | 48        | 389678    | 0.05     
96        | 98        | 384       | 192       | 474868    | 0.15     
384       | 386       | 1536      | 768       | 670404    | 0.43     
1536      | 1538      | 6144      | 3072      | 647458    | 1.78     
6144      | 6146      | 24576     | 12288     | 671209    | 6.87     
24576     | 24578     | 98304     | 49152     | 561476    | 32.83    
98304     | 98306     | 393216    | 196608    | 535278    | 137.74   
393216    | 393218    | 1572864   | 786432    | 507164    | 581.49   
1572864   | 1572866   | 6291456   | 3145728   | 485607    | 2429.22  
Vertices per second, min: 389678, max: 671209, avg: 549238
```

After
------
```
faces     | vertices  | halfedges | edges     | verts/s   | time (ms)
----------+-----------+-----------+-----------+-----------+-----------
24        | 26        | 96        | 48        | 707575    | 0.03     
96        | 98        | 384       | 192       | 919341    | 0.08     
384       | 386       | 1536      | 768       | 1031016   | 0.28     
1536      | 1538      | 6144      | 3072      | 1032396   | 1.12     
6144      | 6146      | 24576     | 12288     | 1034798   | 4.45     
24576     | 24578     | 98304     | 49152     | 892153    | 20.66    
98304     | 98306     | 393216    | 196608    | 804561    | 91.64    
393216    | 393218    | 1572864   | 786432    | 782851    | 376.72   
1572864   | 1572866   | 6291456   | 3145728   | 757301    | 1557.70  
Vertices per second, min: 707575, max: 1034798, avg: 884666
```

Roughly 40-60% faster compared to the master branch, depending on which computer I benchmark it on.

There's one big time sink left and that's the hash map for edges in `mesh::Mesh`. I didn't feel comfortable touching that since I'm not yet familiar enough with the `meshlite` codebase outside of `subdivide.rs`. I'm not going to touch that optimization, at least for a while, since I need to get back to actually using the library now :slightly_smiling_face: 
