### PR TITLE
Optimized triangulate and fixed a bug.

### DIFF
--- a/examples/benchmark_subdivide/main.rs
+++ b/examples/benchmark_subdivide/main.rs
@@ -19,21 +19,20 @@ fn main() {
     println!("----------+-----------+-----------+-----------+-----------+-----------");
     for _ in 0..9 {
         let now = Instant::now();
-        let verts_before = mesh.vertex_count;
-        mesh = mesh.subdivide();
-        let added_verts = mesh.vertex_count - verts_before;
+        let new_mesh = mesh.subdivide();
         let seconds = to_seconds_f64(&now.elapsed());
-        let verts_per_second = (added_verts as f64 / seconds).round();
+        let verts_per_second = (new_mesh.vertex_count as f64 / seconds).round();
         all_vps.push(verts_per_second);
         println!(
             "{: <9} | {: <9} | {: <9} | {: <9} | {: <9} | {: <9.2}",
-            mesh.face_count,
-            mesh.vertex_count,
-            mesh.halfedge_count,
-            mesh.edges.len(),
+            new_mesh.face_count,
+            new_mesh.vertex_count,
+            new_mesh.halfedge_count,
+            new_mesh.edges.len(),
             verts_per_second,
             seconds * 1000.0
         );
+        mesh = new_mesh; // drop the old mesh outside the benchmark timer
     }
     println!(
         "Vertices per second, min: {}, max: {}, avg: {}",

--- a/examples/benchmark_triangulate/main.rs
+++ b/examples/benchmark_triangulate/main.rs
@@ -1,0 +1,52 @@
+extern crate meshlite;
+
+use meshlite::primitives::cube;
+use meshlite::subdivide::Subdivide;
+use meshlite::triangulate::Triangulate;
+use std::time::{Duration, Instant};
+use std::vec::Vec;
+
+fn main() {
+    let mut quad_mesh = cube();
+    let mut all_vps = Vec::new(); // Vertices Per Second
+    println!(concat!(
+        "faces     | ",
+        "vertices  | ",
+        "halfedges | ",
+        "edges     | ",
+        "verts/s   | ",
+        "time (ms)"
+    ));
+    println!("----------+-----------+-----------+-----------+-----------+-----------");
+    let last = 8;
+    for i in 0..=last {
+        let now = Instant::now();
+        let tri_mesh = quad_mesh.triangulate();
+        let seconds = to_seconds_f64(&now.elapsed());
+        let verts_per_second = (tri_mesh.vertex_count as f64 / seconds).round();
+        all_vps.push(verts_per_second);
+        println!(
+            "{: <9} | {: <9} | {: <9} | {: <9} | {: <9} | {: <9.2}",
+            tri_mesh.face_count,
+            tri_mesh.vertex_count,
+            tri_mesh.halfedge_count,
+            tri_mesh.edges.len(),
+            verts_per_second,
+            seconds * 1000.0
+        );
+        if i != last {
+            quad_mesh = quad_mesh.subdivide();
+        }
+    }
+    println!(
+        "Vertices per second, min: {}, max: {}, avg: {}",
+        all_vps.iter().cloned().fold(0. / 0., f64::min),
+        all_vps.iter().cloned().fold(0. / 0., f64::max),
+        (all_vps.iter().sum::<f64>() / all_vps.len() as f64).round()
+    );
+}
+
+fn to_seconds_f64(d: &Duration) -> f64 {
+    d.as_secs() as f64 + d.subsec_nanos() as f64 * 1e-9
+}
+

--- a/profile_dtrace.sh
+++ b/profile_dtrace.sh
@@ -1,9 +1,44 @@
 #!/bin/sh
 
+set -ex
+
+# Profile an example target
+#
+# Dtrace doesn't appear to work reliably, at leasts not on my machine. It will
+# silently fail to output anything for some seemingly random builds or periods
+# of time. I will stop using macOS for profiling from now on, feel free to
+# delete this script.
+# -------------------------
+EXAMPLE='benchmark_triangulate'
+DTRACE_FILE='out.stacks'
+sudo rm -f ${DTRACE_FILE}
+cargo build --release --example ${EXAMPLE}
+sudo dtrace \
+    -c "./target/release/examples/${EXAMPLE}" \
+    -o ${DTRACE_FILE} \
+    -n 'profile-997 /execname == "'${EXAMPLE}'" / { @[ustack(100)] = count(); }'
+sudo chown ${USER} ${DTRACE_FILE}
+sudo chown -R ${USER} target
+../FlameGraph/stackcollapse.pl ${DTRACE_FILE} | ../FlameGraph/flamegraph.pl > flame.svg
+
+# A different example
+# --------------------------
+# EXE_NAME='subdivide_3_high-a0eae922b4b74767'
+# DTRACE_FILE='out.stacks'
+# sudo rm -f ${DTRACE_FILE}
+# target/release/$EXE_NAME --measure-only &
+# BENCH_PID=$!
+# sudo dtrace \
+# 	-p ${BENCH_PID} \
+# 	-o ${DTRACE_FILE} \
+# 	-n "profile-997 /pid == ${BENCH_PID} / { @[ustack(100)] = count(); }"
+# sudo chown $USER out.stacks
+# sudo chown -R $USER target
+# ../FlameGraph/stackcollapse.pl out.stacks | ../FlameGraph/flamegraph.pl > flame.svg
+
+# Based on
+# --------
 # Based on http://carol-nichols.com/2017/04/20/rust-profiling-with-dtrace-on-osx/
 # Make sure to uncomment the debug flag under [profile.release] in Cargo.toml.
 # Needs https://github.com/brendangregg/FlameGraph at ../FlameGraph/
-cargo build --release --example subdiv_benchmark
-sudo dtrace -c './target/release/examples/subdiv_benchmark' -o out.stacks -n 'profile-997 /execname == "subdiv_benchmark"/ { @[ustack(100)] = count(); }'
-../FlameGraph/stackcollapse.pl out.stacks | ../FlameGraph/flamegraph.pl > flame.svg
 

--- a/src/subdivide.rs
+++ b/src/subdivide.rs
@@ -216,11 +216,14 @@ impl<'a> CatmullClarkSubdivider<'a> {
                 for &(added_halfedge_id, added_vertex_id) in
                     added_halfedges.iter()
                 {
-                    self.output
-                        .vertex_mut(added_vertex_id)
-                        .unwrap()
-                        .halfedges
-                        .insert(added_halfedge_id);
+                    {
+                        let vert = self.output
+                            .vertex_mut(added_vertex_id)
+                            .unwrap();
+                        if !vert.halfedges.contains(&added_halfedge_id) {
+                            vert.halfedges.push(added_halfedge_id);
+                        }
+                    }
                     self.output.halfedge_mut(added_halfedge_id).unwrap().face =
                         added_face_id;
                     self.output

--- a/src/triangulate.rs
+++ b/src/triangulate.rs
@@ -1,25 +1,97 @@
-use mesh::Mesh;
-use mesh::Id;
-use std::collections::HashMap;
-use iterator::FaceIterator;
 use iterator::FaceHalfedgeIterator;
+use iterator::FaceIterator;
+use mesh::Id;
+use mesh::Mesh;
 use util::*;
 
 pub trait Triangulate {
     fn triangulate(&self) -> Self;
 }
 
+struct PolygonEdgeCounter {
+    /// Each element represents the number of polygons in the mesh with the same
+    /// number of edges as the index in this sequence. Eg. index 3 contains the
+    /// number of triangles in the mesh, index 4 contains the number of quads in
+    /// the mesh, and so on.
+    pub polygon_edge_counts: Vec<usize>,
+}
+
+impl PolygonEdgeCounter {
+    pub fn new() -> Self {
+        Self {
+            polygon_edge_counts: Vec::new(),
+        }
+    }
+
+    pub fn add_polygon(&mut self, edge_count: usize) {
+        if edge_count >= self.polygon_edge_counts.len() {
+            self.polygon_edge_counts.resize(edge_count + 1, 0);
+        }
+        self.polygon_edge_counts[edge_count] += 1;
+    }
+}
+
+fn predict_triangle_count(pec: &PolygonEdgeCounter) -> usize {
+    let mut sum = 0;
+    for i in 3..pec.polygon_edge_counts.len() {
+        let polygons = pec.polygon_edge_counts[i];
+        sum += polygons * (i - 2);
+    }
+    sum
+}
+
+struct TriangulationPrediction {
+    vertex_count: usize,
+    triangle_count: usize,
+    halfedge_count: usize,
+    edge_count: usize,
+}
+
+impl TriangulationPrediction {
+    pub fn new(input: &Mesh) -> Self {
+        let mut pec = PolygonEdgeCounter::new();
+        for face_id in FaceIterator::new(input) {
+            let halfedge = input.face_first_halfedge_id(face_id).unwrap();
+            let count = FaceHalfedgeIterator::new(input, halfedge).count();
+            pec.add_polygon(count);
+        }
+        let triangle_count = predict_triangle_count(&pec);
+        let halfedge_count = triangle_count * 3;
+        Self {
+            triangle_count,
+            halfedge_count,
+            edge_count: halfedge_count / 2,
+            vertex_count: input.vertex_count,
+        }
+    }
+}
+
 impl Triangulate for Mesh {
+    /// Triangulate without knowing stats about the input mesh.
     fn triangulate(&self) -> Self {
+        let tp = TriangulationPrediction::new(self);
         let mut tri_mesh = Mesh::new();
-        let mut new_vertices : HashMap<Id, Id> = HashMap::new();
+        tri_mesh.vertices.reserve(tp.vertex_count);
+        tri_mesh.faces.reserve(tp.triangle_count);
+        tri_mesh.halfedges.reserve(tp.halfedge_count);
+        tri_mesh.edges.reserve(tp.edge_count);
+        let mut new_vertices: Vec<Option<Id>> =
+            vec![None; self.vertices.len() + 1];
         let mut tri_faces = Vec::new();
+        tri_faces.reserve(tp.triangle_count);
+        let mut vertices = Vec::new();
         for face_id in FaceIterator::new(self) {
-            let mut vertices = Vec::new();
-            let first_halfedge_id = self.face_first_halfedge_id(face_id).unwrap();
-            for halfedge_id in FaceHalfedgeIterator::new(self, first_halfedge_id) {
+            vertices.clear();
+            let first_halfedge_id =
+                self.face_first_halfedge_id(face_id).unwrap();
+            for halfedge_id in
+                FaceHalfedgeIterator::new(self, first_halfedge_id)
+            {
                 let vertex = self.halfedge_start_vertex(halfedge_id).unwrap();
-                new_vertices.entry(vertex.id).or_insert(tri_mesh.add_vertex(vertex.position));
+                let new_vert = &mut new_vertices[vertex.id];
+                if new_vert.is_none() {
+                    *new_vert = Some(tri_mesh.add_vertex(vertex.position));
+                }
                 vertices.push(vertex.id);
             }
             if vertices.len() > 3 {
@@ -34,15 +106,23 @@ impl Triangulate for Mesh {
                         let cone_v = self.vertex(cone).unwrap();
                         let enter_v = self.vertex(enter).unwrap();
                         let leave_v = self.vertex(leave).unwrap();
-                        let angle = angle360(cone_v.position - enter_v.position,
+                        let angle = angle360(
+                            cone_v.position - enter_v.position,
                             leave_v.position - cone_v.position,
-                            direct);
+                            direct,
+                        );
                         if angle >= 1.0 && angle <= 179.0 {
                             let mut is_ear = true;
                             for j in 0..(vertices.len() - 3) {
-                                let fourth = vertices[(i + 3 + j) % vertices.len()];
+                                let fourth =
+                                    vertices[(i + 3 + j) % vertices.len()];
                                 let fourth_v = self.vertex(fourth).unwrap();
-                                if point_in_triangle(enter_v.position, cone_v.position, leave_v.position, fourth_v.position) {
+                                if point_in_triangle(
+                                    enter_v.position,
+                                    cone_v.position,
+                                    leave_v.position,
+                                    fourth_v.position,
+                                ) {
                                     is_ear = false;
                                     break;
                                 }
@@ -64,12 +144,13 @@ impl Triangulate for Mesh {
                 tri_faces.push((vertices[0], vertices[1], vertices[2]));
             }
         }
-        for tri_faces in tri_faces {
-            let mut added_halfedges : Vec<(Id, Id)> = Vec::new();
-            added_halfedges.push((tri_mesh.add_halfedge(), new_vertices[&tri_faces.0]));
-            added_halfedges.push((tri_mesh.add_halfedge(), new_vertices[&tri_faces.1]));
-            added_halfedges.push((tri_mesh.add_halfedge(), new_vertices[&tri_faces.2]));
-            tri_mesh.add_halfedges_and_vertices(added_halfedges);
+        for tf in tri_faces {
+            let array = [
+                (tri_mesh.add_halfedge(), new_vertices[tf.0].unwrap()),
+                (tri_mesh.add_halfedge(), new_vertices[tf.1].unwrap()),
+                (tri_mesh.add_halfedge(), new_vertices[tf.2].unwrap()),
+            ];
+            tri_mesh.add_halfedges_and_vertices(&array);
         }
         tri_mesh
     }

--- a/src/wavefront.rs
+++ b/src/wavefront.rs
@@ -87,7 +87,7 @@ impl Import for Mesh {
                         let index = usize::from_str(index_str).unwrap() - 1;
                         added_halfedges.push((self.add_halfedge(), vertex_array[index]));
                     }
-                    self.add_halfedges_and_vertices(added_halfedges);
+                    self.add_halfedges_and_vertices(&added_halfedges);
                 },
                 _ => ()
             }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,14 +1,22 @@
 extern crate meshlite;
 
-use meshlite::mesh::Mesh;
 use meshlite::primitives::cube;
 use meshlite::subdivide::Subdivide;
+use meshlite::triangulate::Triangulate;
 
 /// Test added for https://github.com/huxingyi/meshlite/pull/2
 #[test]
 fn verify_cube_subdivision() {
-    let mut mesh = cube();
+    let mesh = cube();
     let sub = mesh.subdivide();
     assert_eq!(26, sub.vertex_count);
     assert_eq!(24, sub.face_count);
+}
+
+#[test]
+fn verify_cube_triangulation() {
+    let cube = cube();
+    let tri = cube.triangulate();
+    assert_eq!(8, tri.vertex_count);
+    assert_eq!(12, tri.face_count);
 }


### PR DESCRIPTION
Hello again! I know I said that I were going to stay away from optimization for a while, but I guess that didn't happen :laughing: 

Triangulation is about 200-250% faster.

I have also tweaked the benchmark for subdivision a bit so the `verts/s` doesn't represent the same thing as before, now it represents the total output vertices per second instead of added vertices per second. If instead comparing the run-time for the highest resolution it's about 40% faster (1.1 second on my machine), so that's a nice side effect of this PR.

In this PR I have squashed the commits since I did quite a bit of back and forth, I hope that's Ok.

Oh, and I almost forgot. A bug got fixed too in `triangulate.rs`, there were extra, but unlinked, vertices generated in the output previously.

EDIT: And I forgot the best part! Since 8 days back meshlite is now roughly **1000%, 10x, one order of magnitude faster!** :tada: (see #2)